### PR TITLE
auro-flightline: z-index issues

### DIFF
--- a/src/auro-flightline.js
+++ b/src/auro-flightline.js
@@ -31,9 +31,10 @@ class AuroFlightline extends LitElement {
 
   firstUpdated() {
     // children is an array of auro-flight-segments from within your <slot> below.
-    const slot = this.shadowRoot.querySelector('slot');
-    
-    const children = slot && slot.assignedNodes().
+    /* eslint-disable sort-vars */
+    const slot = this.shadowRoot.querySelector('slot'),
+
+     children = slot && slot.assignedNodes().
       filter((node) => node.nodeName === 'AURO-FLIGHT-SEGMENT');
 
     // if we have a nonstop flight, we need to force _something_ into the dom
@@ -68,9 +69,9 @@ class AuroFlightline extends LitElement {
 
     return html`
       <div class="${classMap(classes)}">
-        ${!this.canceled ? html` <slot></slot>`: html``}
-        ${(this.children.length > ONE && !this.canceled) ? html`
-          <auro-flight-segment iata="${this.children.length} stop${this.children.length > ONE  ? 's' : ''}"></auro-flight-segment>
+        ${this.canceled ? html`` : html` <slot></slot>`}
+        ${this.children.length > ONE && !this.canceled ? html`
+          <auro-flight-segment iata="${this.children.length} stop${this.children.length > ONE ? 's' : ''}"></auro-flight-segment>
         ` : html``}
       </div>`;
   }

--- a/src/style-flight-segment.scss
+++ b/src/style-flight-segment.scss
@@ -7,6 +7,8 @@
 :host {
   flex-grow: 1;
   flex-basis: 0;
+  // prevent z-index declarations from affecting anything outside the component
+  isolation: isolate;
 }
 
 // places the connecting line with a pseudo class

--- a/src/style-flightline.scss
+++ b/src/style-flightline.scss
@@ -36,7 +36,6 @@
     width: 100%;
     position: relative;
     top: 10px;
-    z-index: 1;
   }
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #7

## Summary:

- Remove z-index from the canceled and nonstop lines. It didn't seem to be doing anything.
- Apply isolation: isolate to the flight-segment so that it creates its own [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
- Fix linting errors (not sure why these weren't caught earlier)

Applying the changes made it so the flightline and stops did not appear over the header example linked in [the issue](https://github.com/AlaskaAirlines/auro-flightline/issues/7#issuecomment-862750011). It didn't change how the flightline is shown as far as I could tell.

Tested in Chrome and Firefox on Windows.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
