### PR TITLE
fix(a11y): adds layover readout for screenreaders #13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-flightline",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/auro-flight-segment.js
+++ b/src/auro-flight-segment.js
@@ -58,7 +58,10 @@ class AuroFlightSegment extends LitElement {
         <div class="${classMap(legClasses)}"></div>
         <span class="iata">${this.iata}</span>
         ${this.duration ? html`
-            <auro-badge label>${this.duration}</auro-badge>
+            <auro-badge label>
+              ${this.duration} 
+              <span class="util_displayHiddenVisually"> layover</span>
+            </auro-badge>
         ` : html``}
       </div>
     `;

--- a/src/style-flight-segment.scss
+++ b/src/style-flight-segment.scss
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 // ---------------------------------------------------------------------
+@import "./node_modules/@alaskaairux/webcorestylesheets/dist/utilityClasses/displayProperties";
 
 // forces each segment to take up as much space in its row to extend the ::before
 :host {


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** #13 

## Summary:

Adds a 'layover' readout on our stopover denotation.

## Type of change:

Please delete options that are not relevant.

- [x] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
