### PR TITLE
fix(stop): mobile stop size decreased

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,12 @@ For more information about the difference between a layover and a stopover,
 
 auro-flightline provides a responsive flight timeline experience by placing dots indicating stopovers and layovers on a timeline.
 
+## Properties
+
+| Property   | Attribute  | Type      |
+|------------|------------|-----------|
+| `canceled` | `canceled` | `boolean` |
+
 ## Slots
 
 | Name | Description                                      |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-flightline",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/style-flight-segment.scss
+++ b/src/style-flight-segment.scss
@@ -3,6 +3,8 @@
 
 // ---------------------------------------------------------------------
 @import "./node_modules/@alaskaairux/webcorestylesheets/dist/utilityClasses/displayProperties";
+@import "./node_modules/@alaskaairux/webcorestylesheets/dist/_breakpoints";
+@import "./node_modules/@alaskaairux/design-tokens/dist/tokens/SCSSVariables";
 
 // forces each segment to take up as much space in its row to extend the ::before
 :host {
@@ -36,8 +38,8 @@
 .leg {
   border: 1px solid var(--auro-color-ui-active-on-light);
   border-radius: var(--auro-size-md);
-  width: var(--auro-size-md);
-  height: var(--auro-size-md);
+  width: var(--auro-size-sm);
+  height: var(--auro-size-sm);
 
   &--stopover {
     background-color: var(--auro-color-background-lightest);
@@ -45,6 +47,11 @@
 
   &--layover {
     background-color: var(--auro-color-ui-active-on-light);
+  }
+
+  @include auro_breakpoint--sm {
+    width: var(--auro-size-md);
+    height: var(--auro-size-md);
   }
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** #11

## Summary:

This change adds a media query to decrease the size of the stop on mobile to 12px. This is achieved using a media query with max-width at `auro-breakpoint-sm` (660px) and then setting changing the height and width of the leg from `--auro-size-md` to `--auro-size-sm`.

An additional change is that I noted that when the previous PR was merged in, the API.md file had not been updated for the new `canceled` parameter. This PR updates the API.md file to include it.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [x] Other style change only)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
