### PR TITLE
Remove tokens from generated CSS file

### DIFF
--- a/scripts/postCss.js
+++ b/scripts/postCss.js
@@ -5,7 +5,9 @@ const removeRules = require('postcss-remove-rules')
 const comments = require('postcss-discard-comments')
 const fs = require('fs')
 
-fs.readFile('src/style.css', (err, css) => {
+const cssFiles = ['style-flight-segment', 'style-flightline']
+
+cssFiles.map(name => fs.readFile(`src/${name}.css`, (err, css) => {
   postcss([autoprefixer, postcssCustomProperties, comments])
     .use(comments({
       remove: function(comment) { return comment[0] == "@"; }
@@ -15,11 +17,11 @@ fs.readFile('src/style.css', (err, css) => {
         ':root': '*'
       }
     }))
-    .process(css, { from: 'src/style.css', to: 'src/style.css' })
+    .process(css, { from: `src/${name}.css`, to: `src/${name}.css` })
     .then(result => {
-      fs.writeFile('src/style.css', result.css, () => true)
+      fs.writeFile(`src/${name}.css`, result.css, () => true)
       if ( result.map ) {
-        fs.writeFile('src/style.map', result.map, () => true)
+        fs.writeFile(`src/${name}.map`, result.map, () => true)
       }
     })
-})
+  }));


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** #17

## Summary:

Incorrect PostCSS config allowed for the generated tokens to remain in the generated CSS from Sass. This PR updates the PostCSS config to address this issue. 

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
