### PR TITLE
fix flight segment's layout z-index

### DIFF
--- a/src/style-flight-segment.scss
+++ b/src/style-flight-segment.scss
@@ -31,7 +31,7 @@
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  z-index: 2;
+  z-index: 1;
   width: 100%;
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Changes the z-index of the layout class to 1 in order to prevent the layover/stopover dot from hovering over the mobile navbar. This change is specifically made for the flight search microsite.

**Fixes:** # (issue, if applicable)

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

## Type of change:

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
