### PR TITLE
feat: switch to condensed view based on container width

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -26,7 +26,7 @@ The following illustrates a flight with no layovers or stopovers, for example, S
   <auro-flightline></auro-flightline>
   ```
 </auro-accordion>
- 
+
 ## Canceled
 
 The following illustrates a canceled flight with no layovers or stopovers, for example, SEA to EWR is canceled.
@@ -218,6 +218,74 @@ The following illustrates an cancellation of international flight with stopovers
     <auro-flight-segment iata="ANC" duration="1h 30m"></auro-flight-segment>
     <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
     <auro-flight-segment iata="SFO" duration="1h 40m"></auro-flight-segment>
+  </auro-flightline>
+  ```
+</auro-accordion>
+
+## Container query
+
+The `auro-flightline` element is reactive to its parent container's `width` value versus a `@media` query based on the device `width`. This allows for greater control over the shape of the element when in constrained spaces.
+
+The default container query is a min-width of `414px`. This value can be edited using the `cq` attribute.
+
+The first example illustrates a `auro-flightline` element with a container width of `400px`. The next `auro-flightline` element is within a container set at `100%` for context. Notice when the 100% container reaches a width of < `414px`, the container query switches the UI. The last example illustrates a `auro-flightline` element with a redefined `cq` value of `500px` and a container width of `75%`.
+
+<div class="exampleWrapper">
+  <auro-flightline style="width: 400px">
+    <auro-flight-segment stopover iata="YAK"></auro-flight-segment>
+    <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
+    <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="BOS" duration="1h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="DUB" duration="13h 40m"></auro-flight-segment>
+  </auro-flightline>
+</div>
+
+<div class="exampleWrapper">
+  <auro-flightline>
+    <auro-flight-segment stopover iata="YAK"></auro-flight-segment>
+    <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
+    <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="BOS" duration="1h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="DUB" duration="13h 40m"></auro-flight-segment>
+  </auro-flightline>
+</div>
+
+<div class="exampleWrapper">
+  <auro-flightline cq="500" style="width: 50%">
+    <auro-flight-segment stopover iata="YAK"></auro-flight-segment>
+    <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
+    <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="BOS" duration="1h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="DUB" duration="13h 40m"></auro-flight-segment>
+  </auro-flightline>
+</div>
+
+<auro-accordion lowProfile justifyRight>
+  <span slot="trigger">See code</span>
+
+  ```html
+  <auro-flightline style="width: 400px">
+    <auro-flight-segment stopover iata="YAK"></auro-flight-segment>
+    <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
+    <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="BOS" duration="1h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="DUB" duration="13h 40m"></auro-flight-segment>
+  </auro-flightline>
+
+  <auro-flightline>
+    <auro-flight-segment stopover iata="YAK"></auro-flight-segment>
+    <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
+    <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="BOS" duration="1h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="DUB" duration="13h 40m"></auro-flight-segment>
+  </auro-flightline>
+
+  <auro-flightline cq="500" style="width: 50%">
+    <auro-flight-segment stopover iata="YAK"></auro-flight-segment>
+    <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
+    <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="BOS" duration="1h 40m"></auro-flight-segment>
+    <auro-flight-segment iata="DUB" duration="13h 40m"></auro-flight-segment>
   </auro-flightline>
   ```
 </auro-accordion>

--- a/demo/demo.md
+++ b/demo/demo.md
@@ -228,7 +228,7 @@ The `auro-flightline` element is reactive to its parent container's `width` valu
 
 The default container query is a min-width of `414px`. This value can be edited using the `cq` attribute.
 
-The first example illustrates a `auro-flightline` element with a container width of `400px`. The next `auro-flightline` element is within a container set at `100%` for context. Notice when the 100% container reaches a width of < `414px`, the container query switches the UI. The last example illustrates a `auro-flightline` element with a redefined `cq` value of `500px` and a container width of `75%`.
+The first example illustrates a `auro-flightline` element with a container width of `400px`. The next `auro-flightline` element is within a container set at `100%` for context. Notice when the 100% container reaches a width of < `414px`, the container query switches the UI. The last example illustrates a `auro-flightline` element with a redefined `cq` value of `500px` and a container width of `75%`. Resize the screen to see it switch between a summarized and expanded view when its width reaches `500px`.
 
 <div class="exampleWrapper">
   <auro-flightline style="width: 400px">
@@ -251,7 +251,7 @@ The first example illustrates a `auro-flightline` element with a container width
 </div>
 
 <div class="exampleWrapper">
-  <auro-flightline cq="500" style="width: 50%">
+  <auro-flightline cq="500" style="width: 75%">
     <auro-flight-segment stopover iata="YAK"></auro-flight-segment>
     <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
     <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
@@ -280,7 +280,7 @@ The first example illustrates a `auro-flightline` element with a container width
     <auro-flight-segment iata="DUB" duration="13h 40m"></auro-flight-segment>
   </auro-flightline>
 
-  <auro-flightline cq="500" style="width: 50%">
+  <auro-flightline cq="500" style="width: 75%">
     <auro-flight-segment stopover iata="YAK"></auro-flight-segment>
     <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
     <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,9 +21,10 @@ auro-flightline provides a responsive flight timeline experience by placing dots
 
 ## Properties
 
-| Property   | Attribute  | Type      | Default |
-|------------|------------|-----------|---------|
-| `canceled` | `canceled` | `boolean` | false   |
+| Property     | Attribute    | Type      | Default | Description                                      |
+|--------------|--------------|-----------|---------|--------------------------------------------------|
+| `breakpoint` | `breakpoint` | `Number`  | 414     | The number of pixels where the component should switch to an expanded view. |
+| `canceled`   | `canceled`   | `Boolean` | false   | Whether the flightline is canceled.              |
 
 ## Slots
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,10 +21,10 @@ auro-flightline provides a responsive flight timeline experience by placing dots
 
 ## Properties
 
-| Property     | Attribute    | Type      | Default | Description                                      |
-|--------------|--------------|-----------|---------|--------------------------------------------------|
-| `breakpoint` | `breakpoint` | `Number`  | 414     | The number of pixels where the component should switch to an expanded view. |
-| `canceled`   | `canceled`   | `Boolean` | false   | Whether the flightline is canceled.              |
+| Property   | Attribute  | Type      | Default | Description                                      |
+|------------|------------|-----------|---------|--------------------------------------------------|
+| `canceled` | `canceled` | `Boolean` | false   | Whether the flightline is canceled.              |
+| `cq`       | `cq`       | `Number`  | 414     | The number of pixels where the component should switch to an expanded view. |
 
 ## Slots
 

--- a/src/auro-flight-segment.js
+++ b/src/auro-flight-segment.js
@@ -49,13 +49,15 @@ class AuroFlightSegment extends LitElement {
   // function that renders the HTML and CSS into  the scope of the component
   render() {
     const legClasses = {
+      'leg': true,
+      'layout': true,
       'leg--stopover': this.stopover
     };
 
     return html`
       <div class="layout">
         <slot></slot>
-        <div class="leg layout ${classMap(legClasses)}"></div>
+        <div class="${classMap(legClasses)}"></div>
         <span class="iata">${this.iata}</span>
         ${this.duration ? html`
             <auro-badge label>

--- a/src/auro-flight-segment.js
+++ b/src/auro-flight-segment.js
@@ -49,16 +49,13 @@ class AuroFlightSegment extends LitElement {
   // function that renders the HTML and CSS into  the scope of the component
   render() {
     const legClasses = {
-      'leg': true,
-      'layout': true,
-      'leg--stopover': this.stopover,
-      'leg--layover': !this.stopover,
+      'leg--stopover': this.stopover
     };
 
     return html`
       <div class="layout">
         <slot></slot>
-        <div class="${classMap(legClasses)}"></div>
+        <div class="leg layout ${classMap(legClasses)}"></div>
         <span class="iata">${this.iata}</span>
         ${this.duration ? html`
             <auro-badge label>

--- a/src/auro-flightline.js
+++ b/src/auro-flightline.js
@@ -12,13 +12,13 @@ import "focus-visible/dist/focus-visible.min.js";
 import styleCss from "./style-flightline-css.js";
 import { observeResize, unobserve } from './observer';
 
-const defaultBreakpoint = 414;
+const defaultContainerWidth = 414;
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
  * auro-flightline provides a responsive flight timeline experience by placing dots indicating stopovers and layovers on a timeline.
  * @attr {Boolean} canceled - Whether the flightline is canceled.
- * @attr {Number} breakpoint - The number of pixels where the component should switch to an expanded view.
+ * @attr {Number} cq - The number of pixels where the component should switch to an expanded view.
  * @slot - fill in with `<auro-flight-segment>` components of a given leg.
  */
 
@@ -26,17 +26,17 @@ class AuroFlightline extends LitElement {
   constructor() {
     super();
     this.canceled = false;
-    this.breakpoint = defaultBreakpoint;
+    this.cq = defaultContainerWidth;
 
     /** @private */
-    this.expanded = false;
+    this.showAllStops = false;
   }
 
   static get properties() {
     return {
       canceled:    { type: Boolean },
-      expanded:    { type: Boolean },
-      breakpoint:  { type: Number }
+      showAllStops:    { type: Boolean },
+      cq:  { type: Number }
     };
   }
 
@@ -47,12 +47,12 @@ class AuroFlightline extends LitElement {
   }
 
   firstUpdated() {
-    const setExpanded = (val) => {
-      this.expanded = val > this.breakpoint;
+    const setShowAllStops = (val) => {
+      this.showAllStops = val > this.cq;
     };
 
     this.observedNode = this;
-    observeResize(this.observedNode, setExpanded);
+    observeResize(this.observedNode, setShowAllStops);
   }
 
   disconnectedCallback() {
@@ -67,7 +67,7 @@ class AuroFlightline extends LitElement {
       'nonstop': !this.children.length && !this.canceled,
       'multiple': isMultiple,
       'canceled': this.canceled,
-      'expanded': this.expanded
+      'show-all-stops': this.showAllStops
     };
 
     return html`

--- a/src/auro-flightline.js
+++ b/src/auro-flightline.js
@@ -63,6 +63,7 @@ class AuroFlightline extends LitElement {
   render() {
     const isMultiple = this.children.length > 1;
     const classes = {
+      'slot-container': true,
       'nonstop': !this.children.length && !this.canceled,
       'multiple': isMultiple,
       'canceled': this.canceled,
@@ -70,7 +71,7 @@ class AuroFlightline extends LitElement {
     };
 
     return html`
-      <div class="slot-container ${classMap(classes)}">
+      <div class="${classMap(classes)}">
         ${this.canceled ? html`` : html` <slot></slot>`}
         ${isMultiple && !this.canceled ? html`
           <auro-flight-segment iata="${this.children.length} stops"></auro-flight-segment>

--- a/src/auro-flightline.js
+++ b/src/auro-flightline.js
@@ -12,12 +12,13 @@ import "focus-visible/dist/focus-visible.min.js";
 import styleCss from "./style-flightline-css.js";
 import { observeResize, unobserve } from './observer';
 
-const SMALL_BREAKPOINT = 660;
+const defaultBreakpoint = 414;
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
  * auro-flightline provides a responsive flight timeline experience by placing dots indicating stopovers and layovers on a timeline.
- *
+ * @attr {Boolean} canceled - Whether the flightline is canceled.
+ * @attr {Number} breakpoint - The number of pixels where the component should switch to an expanded view.
  * @slot - fill in with `<auro-flight-segment>` components of a given leg.
  */
 
@@ -25,15 +26,17 @@ class AuroFlightline extends LitElement {
   constructor() {
     super();
     this.canceled = false;
+    this.breakpoint = defaultBreakpoint;
 
     /** @private */
-    this.condensed = false;
+    this.expanded = false;
   }
 
   static get properties() {
     return {
       canceled:    { type: Boolean },
-      condensed:   { type: Boolean }
+      expanded:    { type: Boolean },
+      breakpoint:  { type: Number }
     };
   }
 
@@ -44,13 +47,12 @@ class AuroFlightline extends LitElement {
   }
 
   firstUpdated() {
-    // if the container's width drops below the small breakpoint, force the condensed view
-    const setCondensed = (val) => {
-      this.condensed = val < SMALL_BREAKPOINT;
+    const setExpanded = (val) => {
+      this.expanded = val > this.breakpoint;
     };
 
     this.observedNode = this;
-    observeResize(this.observedNode, setCondensed);
+    observeResize(this.observedNode, setExpanded);
   }
 
   disconnectedCallback() {
@@ -64,7 +66,7 @@ class AuroFlightline extends LitElement {
       'nonstop': !this.children.length && !this.canceled,
       'multiple': isMultiple,
       'canceled': this.canceled,
-      'condensed': this.condensed
+      'expanded': this.expanded
     };
 
     return html`

--- a/src/observer.js
+++ b/src/observer.js
@@ -8,10 +8,7 @@ const callbacks = new Map();
 function resizeCallback(target) {
   const { width } = target.getBoundingClientRect();
 
-  // requestAnimationFrame prevents a "ResizeObserver loop limit exceeded" error in the tests
-  window.requestAnimationFrame(() => {
-    callbacks.get(target)(width);
-  });
+  callbacks.get(target)(width);
 }
 
 /**

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,0 +1,54 @@
+/** @type {Map<Node, resizeCallback>} */
+const callbacks = new Map();
+
+/**
+ * Handle the resize event.
+ * @param {Element} target - The observed node.
+ */
+function resizeCallback(target) {
+  const { width } = target.getBoundingClientRect();
+
+  // requestAnimationFrame prevents a "ResizeObserver loop limit exceeded" error in the tests
+  window.requestAnimationFrame(() => {
+    callbacks.get(target)(width);
+  });
+}
+
+/**
+ * Callback for the resize observer.
+ * In the future, this could be replaced with CSS container queries.
+ * @param {ResizeObserverEntry[]} entries - Elements that have been resized.
+ * @returns {void}
+ */
+function handleResize(entries) {
+  entries.forEach(({target}) => resizeCallback(target));
+}
+
+// this observer is shared between all auro-flightline instances on a page
+const ro = new ResizeObserver(handleResize);
+
+/**
+ * @callback resizeCallback
+ * @param {number} width
+ */
+
+/**
+ * Observe changes to a node's width.
+ * @param {Node} node - The node to observe.
+ * @param {resizeCallback} cb - The callback to execute when the node's width changes.
+ */
+export function observeResize(node, cb) {
+  callbacks.set(node, cb);
+  ro.observe(node);
+  // call immediately to prevent FOUC
+  resizeCallback(node);
+}
+
+/**
+ * Unobserve a node.
+ * @param {Node} node - The node to unobserve.
+ */
+export function unobserve(node) {
+  ro.unobserve(node);
+  callbacks.delete(node);
+}

--- a/src/style-flight-segment.scss
+++ b/src/style-flight-segment.scss
@@ -40,13 +40,10 @@
   border-radius: var(--auro-size-md);
   width: var(--auro-size-sm);
   height: var(--auro-size-sm);
+  background-color: var(--auro-color-ui-active-on-light);
 
   &--stopover {
     background-color: var(--auro-color-background-lightest);
-  }
-
-  &--layover {
-    background-color: var(--auro-color-ui-active-on-light);
   }
 
   @include auro_breakpoint--sm {

--- a/src/style-flightline.scss
+++ b/src/style-flightline.scss
@@ -34,7 +34,7 @@
   background-color: var(--auro-color-brand-atlas-500);
 }
 
-.canceled::before{
+.canceled::before {
   border-top: var(--auro-size-xxxs) dashed var(--auro-color-alert-error-on-light);
 }
 
@@ -44,11 +44,11 @@
   display: none;
 }
 
-.multiple.expanded ::slotted(*) {
+.multiple.show-all-stops ::slotted(*) {
   display: block;
 }
 
-.expanded auro-flight-segment {
+.show-all-stops auro-flight-segment {
   display: none;
 }
 

--- a/src/style-flightline.scss
+++ b/src/style-flightline.scss
@@ -9,6 +9,10 @@
 @import "./node_modules/@alaskaairux/webcorestylesheets/dist/breakpoints";
 @import "./node_modules/@alaskaairux/webcorestylesheets/dist/core";
 
+:host {
+  display: block;
+}
+
 .slot-container {
   min-height: var(--auro-size-lg);
 }
@@ -38,24 +42,14 @@
 // for multiple we want to just show N stops in a layover dot.
 .multiple ::slotted(*) {
   display: none;
-
-  @include auro_breakpoint--sm {
-    display: block;
-  }
 }
 
-// when the container becomes too small, show the summary segment, not all the segments 
-.condensed.multiple ::slotted(*) {
-  display: none;
-}
-.condensed.multiple auro-flight-segment {
+.multiple.expanded ::slotted(*) {
   display: block;
 }
 
-auro-flight-segment {
-  @include auro_breakpoint--sm {
-    display: none;
-  }
+.expanded auro-flight-segment {
+  display: none;
 }
 
 // flex container for the slot

--- a/src/style-flightline.scss
+++ b/src/style-flightline.scss
@@ -33,6 +33,7 @@
 .canceled::before{
   border-top: var(--auro-size-xxxs) dashed var(--auro-color-alert-error-on-light);
 }
+
 // when there's only one connection, we want to show the actual dot but
 // for multiple we want to just show N stops in a layover dot.
 .multiple ::slotted(*) {
@@ -41,6 +42,14 @@
   @include auro_breakpoint--sm {
     display: block;
   }
+}
+
+// when the container becomes too small, show the summary segment, not all the segments 
+.condensed.multiple ::slotted(*) {
+  display: none;
+}
+.condensed.multiple auro-flight-segment {
+  display: block;
 }
 
 auro-flight-segment {
@@ -53,8 +62,4 @@ auro-flight-segment {
 .slot-container {
   display: flex;
   justify-content: space-around;
-
-  &.multiple::slotted(*) {
-    display: none;
-  }
 }

--- a/test/auro-flightline.test.js
+++ b/test/auro-flightline.test.js
@@ -1,4 +1,4 @@
-import { fixture, html, expect } from '@open-wc/testing';
+import { fixture, html, expect, waitUntil } from '@open-wc/testing';
 import '../src/auro-flightline.js';
 import '../src/auro-flight-segment.js';
 
@@ -58,6 +58,31 @@ describe('auro-flightline', () => {
     const el = await Boolean(customElements.get("auro-flightline"));
 
     await expect(el).to.be.true;
+  });
+
+  it('shows condensed view when not enough room', async () => {
+    const el = await fixture(html`
+      <auro-flightline id="condensed">
+        <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
+        <auro-flight-segment iata="BOS" duration="1h 40m"></auro-flight-segment>
+        <auro-flight-segment iata="DUB" duration="13h 40m"></auro-flight-segment>
+      </auro-flightline>
+    `);
+
+    const slottedSegment = el.querySelector('auro-flight-segment');
+    const condensedSegment = el.shadowRoot.querySelector('auro-flight-segment');
+
+    // when too narrow to show all segments, the condensed segment is shwon
+    el.style.width = "100px";
+    await waitUntil(() => el.condensed);
+    expect(window.getComputedStyle(slottedSegment).display).to.eql('none');
+    expect(window.getComputedStyle(condensedSegment).display).to.eql('block');
+
+    // when the element is resized, the expanded view is shown
+    el.style.width = "700px";
+    await waitUntil(() => !el.condensed);
+    expect(window.getComputedStyle(slottedSegment).display).to.eql('block');
+    expect(window.getComputedStyle(condensedSegment).display).to.eql('none');
   });
 });
 

--- a/test/auro-flightline.test.js
+++ b/test/auro-flightline.test.js
@@ -4,7 +4,7 @@ import '../src/auro-flight-segment.js';
 
 describe('auro-flightline', () => {
 
-  it('auro-flightline is accessible', async () => {
+  it('is accessible', async () => {
     const el = await fixture(html`
       <auro-flightline>
       </auro-flightline>
@@ -13,7 +13,7 @@ describe('auro-flightline', () => {
     await expect(el).to.be.accessible();
   });
 
-  it('auro-flightline with canceled status', async () => {
+  it('with canceled status', async () => {
     const el = await fixture(html`
       <auro-flightline canceled>
       </auro-flightline>
@@ -22,7 +22,7 @@ describe('auro-flightline', () => {
     await expect(el.classList.contains("canceled"));
   });
 
-  it('auro-flightline with canceled status do not display a layover', async () => {
+  it('with canceled status do not display a layover', async () => {
     const el = await fixture(html`
       <auro-flightline canceled>
         <auro-flight-segment iata="SEA"></auro-flight-segment>
@@ -33,7 +33,7 @@ describe('auro-flightline', () => {
     await expect(el.shadowRoot.querySelectorAll('auro-flight-segment').length).to.equal(0);
   });
 
-  it('auro-flightline with canceled status do not display a stopover', async () => {
+  it('with canceled status do not display a stopover', async () => {
     const el = await fixture(html`
       <auro-flightline canceled>
         <auro-flight-segment iata="SEA" stopover></auro-flight-segment>
@@ -43,7 +43,7 @@ describe('auro-flightline', () => {
     await expect(el.shadowRoot.querySelectorAll('auro-flight-segment').length).to.equal(0);
   });
 
-  it('auro-flightline with a layover', async () => {
+  it('with a layover', async () => {
     const el = await fixture(html`
       <auro-flightline>
         <auro-flight-segment iata="SEA"></auro-flight-segment>
@@ -54,7 +54,15 @@ describe('auro-flightline', () => {
     await expect(el).to.be.accessible();
   });
 
-  it('auro-flight-segment with a layover', async () => {
+  it('custom element is defined', async () => {
+    const el = await Boolean(customElements.get("auro-flightline"));
+
+    await expect(el).to.be.true;
+  });
+});
+
+describe('auro-flight-segment', () => {  
+  it('with a layover', async () => {
     const el = await fixture(html`
       <auro-flight-segment iata="SEA" duration="1h 2m"></auro-flight-segment>
     `);
@@ -63,7 +71,7 @@ describe('auro-flightline', () => {
     await expect(el.shadowRoot.querySelectorAll('auro-badge').length).to.equal(1);
   });
 
-  it('auro-flight-segment with a layover no duration', async () => {
+  it('with a layover no duration', async () => {
     const el = await fixture(html`
       <auro-flight-segment iata="2 Stops"></auro-flight-segment>
     `);
@@ -72,17 +80,11 @@ describe('auro-flightline', () => {
     await expect(el.shadowRoot.querySelectorAll('auro-badge').length).to.equal(0);
   });
 
-  it('auro-flight-segment with a stopover', async () => {
+  it('with a stopover', async () => {
     const el = await fixture(html`
       <auro-flight-segment iata="SEA" stopover></auro-flight-segment>
     `);
 
     await expect(el.shadowRoot.querySelector('span').innerHTML).to.equal('<!---->SEA<!---->');
   });
-
-  it('auro-flightline custom element is defined', async () => {
-    const el = await Boolean(customElements.get("auro-flightline"));
-
-    await expect(el).to.be.true;
-  });
-});
+})

--- a/test/auro-flightline.test.js
+++ b/test/auro-flightline.test.js
@@ -60,7 +60,7 @@ describe('auro-flightline', () => {
     await expect(el).to.be.true;
   });
 
-  it('shows condensed view when not enough room', async () => {
+  it('shows expanded view depending on width', async () => {
     const el = await fixture(html`
       <auro-flightline id="condensed">
         <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
@@ -70,19 +70,19 @@ describe('auro-flightline', () => {
     `);
 
     const slottedSegment = el.querySelector('auro-flight-segment');
-    const condensedSegment = el.shadowRoot.querySelector('auro-flight-segment');
+    const summarySegment = el.shadowRoot.querySelector('auro-flight-segment');
 
     // when too narrow to show all segments, the condensed segment is shwon
     el.style.width = "100px";
-    await waitUntil(() => el.condensed);
+    await waitUntil(() => !el.expanded);
     expect(window.getComputedStyle(slottedSegment).display).to.eql('none');
-    expect(window.getComputedStyle(condensedSegment).display).to.eql('block');
+    expect(window.getComputedStyle(summarySegment).display).to.eql('block');
 
     // when the element is resized, the expanded view is shown
     el.style.width = "700px";
-    await waitUntil(() => !el.condensed);
+    await waitUntil(() => el.expanded);
     expect(window.getComputedStyle(slottedSegment).display).to.eql('block');
-    expect(window.getComputedStyle(condensedSegment).display).to.eql('none');
+    expect(window.getComputedStyle(summarySegment).display).to.eql('none');
   });
 });
 

--- a/test/auro-flightline.test.js
+++ b/test/auro-flightline.test.js
@@ -2,6 +2,21 @@ import { fixture, html, expect, waitUntil } from '@open-wc/testing';
 import '../src/auro-flightline.js';
 import '../src/auro-flight-segment.js';
 
+// This suppresses ResizeObserver errors that only show up in the tests
+// Ref: https://stackoverflow.com/a/64197640/14808988
+before(() => {
+  // called before any tests are run
+  const e = window.onerror;
+  window.onerror = function(err) {
+    if(err === 'ResizeObserver loop limit exceeded') {
+      console.warn('Ignored: ResizeObserver loop limit exceeded');
+      return false;
+    } else {
+      return e(...arguments);
+    }
+  }
+});
+
 describe('auro-flightline', () => {
 
   it('is accessible', async () => {

--- a/test/auro-flightline.test.js
+++ b/test/auro-flightline.test.js
@@ -75,7 +75,7 @@ describe('auro-flightline', () => {
     await expect(el).to.be.true;
   });
 
-  it('shows expanded view depending on width', async () => {
+  it('shows all stops depending on width', async () => {
     const el = await fixture(html`
       <auro-flightline id="condensed">
         <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
@@ -89,13 +89,13 @@ describe('auro-flightline', () => {
 
     // when too narrow to show all segments, the condensed segment is shwon
     el.style.width = "100px";
-    await waitUntil(() => !el.expanded);
+    await waitUntil(() => !el.showAllStops);
     expect(window.getComputedStyle(slottedSegment).display).to.eql('none');
     expect(window.getComputedStyle(summarySegment).display).to.eql('block');
 
     // when the element is resized, the expanded view is shown
     el.style.width = "700px";
-    await waitUntil(() => el.expanded);
+    await waitUntil(() => el.showAllStops);
     expect(window.getComputedStyle(slottedSegment).display).to.eql('block');
     expect(window.getComputedStyle(summarySegment).display).to.eql('none');
   });


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes https://github.com/AlaskaAirlines/auro-flight/issues/19

## Summary:

- When an individual flightline's width drops below 414px, it switches to the condensed view seen on mobile. This breakpoint is customizable via the `breakpoint` property on the flightline.
- Use ResizeObserver to detect changes to element size. The RO is shared between all flightline instances on a page.
- Refactor: remove --layover class. This was always added, so we didn't need a separate declaration.

Dale suggested looking into the cqfill package to polyfill CSS container queries. However, I was unable to get that package to work with web components (see discussion in linked auro-flight issue). I couldn't find any other stable polyfill, options, so I opted to keep my original ResizeObserver solution instead. This should be relatively easy to swap out for container queries when they're available in browsers -- instead of setting a `condensed` class, use a media query instead and remove the observer code.

If anyone has suggestions for alternate solutions for me to investigate, let me know.

Before (675px screen width):
![image](https://user-images.githubusercontent.com/4992896/138176334-af61d13b-e57c-4893-9493-d80cbeb0be23.png)

After:
![image](https://user-images.githubusercontent.com/4992896/138176423-3bb2b45f-9651-4034-af4f-c3480fbcb6c9.png)


As a demonstration, add the following HTML to the demo and resize the screen.

```html
<style>
  .grid {
    display: grid;
    grid-template-columns: 1fr 1fr;
    gap: 2rem;
  }
</style>

<div class="grid">
  <auro-flightline id="flight1">
    <auro-flight-segment stopover iata="YAK"></auro-flight-segment>
    <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
    <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
    <auro-flight-segment iata="BOS" duration="1h 40m"></auro-flight-segment>
    <auro-flight-segment iata="DUB" duration="13h 40m"></auro-flight-segment>
  </auro-flightline>
  <auro-flightline id="flight2">
    <auro-flight-segment stopover iata="YAK"></auro-flight-segment>
    <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
    <auro-flight-segment iata="SEA" duration="0h 40m"></auro-flight-segment>
    <auro-flight-segment iata="BOS" duration="1h 40m"></auro-flight-segment>
    <auro-flight-segment iata="DUB" duration="13h 40m"></auro-flight-segment>
  </auro-flightline>
</div>
```

## Type of change:

Please delete options that are not relevant.

- [x] New capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
