### PR TITLE
fix(ssr): Add missing extension to badgeVersion import

### DIFF
--- a/src/auro-flight-segment.js
+++ b/src/auro-flight-segment.js
@@ -17,7 +17,7 @@ import tokensCss from "./tokens-css.js";
 
 import { AuroDependencyVersioning } from '@aurodesignsystem/auro-library/scripts/runtime/dependencyTagVersioning.mjs';
 import { AuroBadge } from '@aurodesignsystem/auro-badge/src/auro-badge.js';
-import badgeVersion from './badgeVersion';
+import badgeVersion from './badgeVersion.js';
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**


### PR DESCRIPTION
# Alaska Airlines Pull Request

Adds a missing extension to the badgeVersion import in auro-flight-segment that is causing SSR to fail in ESM projects

10:06:15 AM [vite] Error when evaluating SSR module /src/routes/guest-info/+page.svelte: failed to import "@aurodesignsystem/auro-flight"
|- Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/x/source/booking/node_modules/@aurodesignsystem/auro-flightline/src/badgeVersion' imported from /Users/x/source/booking/node_modules/@aurodesignsystem/auro-flightline/src/auro-flight-segment.js

works fine when rendered client side

## Summary:

Just adds the extension to the badgeVersion import, tested locally and confirmed it fixes SSR

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [X] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
