### PR TITLE
fix: add `reflect: true` on boolean props

### DIFF
--- a/src/auro-flight-segment.js
+++ b/src/auro-flight-segment.js
@@ -48,18 +48,28 @@ export class AuroFlightSegment extends LitElement {
   // function to define props used within the scope of this component
   static get properties() {
     return {
-      stopover:   { type: Boolean },
+      stopover: {
+        type: Boolean,
+        reflect: true
+      },
       nextDay: {
         type: Boolean,
         reflect: true
       },
       iata:       { type: String },
       duration:   { type: String },
-      canceled:   { type: Boolean,
-        reflect: true },
-      destinationCanceled: { type: Boolean,
-        reflect: true },
-      partialCancel: { type: Boolean }
+      canceled:   {
+        type: Boolean,
+        reflect: true
+      },
+      destinationCanceled: {
+        type: Boolean,
+        reflect: true
+      },
+      partialCancel: {
+        type: Boolean,
+        reflect: true
+      }
     };
   }
 

--- a/src/auro-flightline.js
+++ b/src/auro-flightline.js
@@ -1,3 +1,4 @@
+/* eslint-disable object-property-newline */
 // Copyright (c) 2021 Alaska Airlines. All right reserved. Licensed under the Apache-2.0 license
 // See LICENSE in the project root for license information.
 
@@ -48,10 +49,10 @@ export class AuroFlightline extends LitElement {
 
   static get properties() {
     return {
-      canceled:    { type: Boolean },
-      hasCanceledSegment: { type: Boolean },
-      firstSegmentCanceled: { type: Boolean },
-      lastSegmentCanceled: { type: Boolean }
+      canceled:    { type: Boolean, reflect: true },
+      hasCanceledSegment: { type: Boolean, reflect: true },
+      firstSegmentCanceled: { type: Boolean, reflect: true },
+      lastSegmentCanceled: { type: Boolean, reflect: true }
     };
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add `reflect: true` to boolean properties in Auro flight-related components to ensure proper attribute reflection

Bug Fixes:
- Ensured consistent attribute reflection for boolean properties in AuroFlightSegment and AuroFlightline components

Enhancements:
- Updated property definitions to include `reflect: true` for boolean properties in multiple components